### PR TITLE
udev: skipping error check for EINTR

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -12,6 +12,7 @@ package udev
 import "C"
 import (
 	"errors"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -178,6 +179,11 @@ func (m *Monitor) DeviceChan(done <-chan struct{}) (<-chan *Device, error) {
 			// Poll the file descriptor
 			nevents, e := unix.EpollWait(epfd, events[:], epollTimeout)
 			if e != nil {
+				if errno, ok := e.(syscall.Errno); ok {
+					if errno == syscall.EINTR {
+						continue
+					}
+				}
 				return
 			}
 			// Process events


### PR DESCRIPTION
## What this PR does

Adds a check to ignore `EINTR` errors to continue monitoring even if the source program receives any signal.

## Additional details 

If the program that uses `go-udev` receives an interruption (`SIGINT`),  `go-udev` stops monitoring and closes the channel. But this should only be the case when gracefully closed by `done`. Checking and continuing for `EINTR` would ensure that monitoring continues without stopping even if the source program receives any signal (usually when `EINTR` is seen).