### PR TITLE
device: add Sysname() getter

### DIFF
--- a/device.go
+++ b/device.go
@@ -82,6 +82,13 @@ func (d *Device) Devtype() string {
 	return C.GoString(C.udev_device_get_devtype(d.ptr))
 }
 
+// Sysname returns the sysname of the udev device (e.g. ttyS3, sda1...).
+func (d *Device) Sysname() string {
+	d.lock()
+	defer d.unlock()
+	return C.GoString(C.udev_device_get_sysname(d.ptr))
+}
+
 // Syspath returns the sys path of the udev device.
 // The path is an absolute path and starts with the sys mount point.
 func (d *Device) Syspath() string {

--- a/device_test.go
+++ b/device_test.go
@@ -17,6 +17,7 @@ func ExampleDevice() {
 	d := u.NewDeviceFromSubsystemSysname("mem", "zero")
 
 	// Extract information
+	fmt.Printf("Sysname:%v\n", d.Sysname())
 	fmt.Printf("Syspath:%v\n", d.Syspath())
 	fmt.Printf("Devpath:%v\n", d.Devpath())
 	fmt.Printf("Devnode:%v\n", d.Devnode())
@@ -33,6 +34,7 @@ func ExampleDevice() {
 		_ = fmt.Sprintf("Property:%v=%v\n", kv[0], kv[1])
 	})
 	// Output:
+	// Sysname:zero
 	// Syspath:/sys/devices/virtual/mem/zero
 	// Devpath:/devices/virtual/mem/zero
 	// Devnode:/dev/zero
@@ -47,6 +49,9 @@ func TestDeviceZero(t *testing.T) {
 	u := Udev{}
 	d := u.NewDeviceFromDeviceID("c1:5")
 	if d.Subsystem() != "mem" {
+		t.Fail()
+	}
+	if d.Sysname() != "zero" {
 		t.Fail()
 	}
 	if d.Syspath() != "/sys/devices/virtual/mem/zero" {


### PR DESCRIPTION
Add a method `Sysname()` to get the device's sysname.